### PR TITLE
[FIX] Incorrect ABoot Header stripping

### DIFF
--- a/AbootConverter.py
+++ b/AbootConverter.py
@@ -36,7 +36,7 @@ def inputNumber(str, min, max, default) -> int:
 
 
 def detectFlatHardDiskGeometry(filename):
-    # Detect geometry of a flat harddisk file.abootHeaderSize
+    # Detect geometry of a flat harddisk file.
     # Take the file size and create a proper CHS for that.
     realFileSize = os.path.getsize(filename)
     # print("realsize size = %d" % realFileSize)

--- a/AbootConverter.py
+++ b/AbootConverter.py
@@ -36,7 +36,7 @@ def inputNumber(str, min, max, default) -> int:
 
 
 def detectFlatHardDiskGeometry(filename):
-    # Detect geometry of a flat harddisk file.
+    # Detect geometry of a flat harddisk file.abootHeaderSize
     # Take the file size and create a proper CHS for that.
     realFileSize = os.path.getsize(filename)
     # print("realsize size = %d" % realFileSize)
@@ -88,10 +88,14 @@ def main(argv):
         if ofilestring == "":
             ofilestring = filenameout
 
+        print("Skipping rest of ABOOT header...")
+        fin.read(abootHeaderSize - 14)
+
+        print("Writing stripped HDD image file...")
         fout = open(filenameout, "wb")
         fout.write(fin.read())
         fout.close()
-        print("Successfully. You can mount the image now with DOSBox command:\n")
+        print("Success! You can mount the image now with DOSBox command:\n")
         print(" IMGMOUNT C %s -size 512,%d,%d,%d -t hdd\n" % (filenameout, sectors, heads, cylinders))
 
     elif detectFlatImage(filename):


### PR DESCRIPTION
Stripping the ABoot header from the disk image files does not skip the whole header but only the first 14 bytes. This results in corrupt disk images one cannot mount with DOSBox, Linux, etc.

This PR makes sure the the header is completely removed from the resulting image.